### PR TITLE
fix: ios build issue when using use_frameworks! static

### DIFF
--- a/ios/Ting.mm
+++ b/ios/Ting.mm
@@ -1,6 +1,11 @@
 #import "Ting.h"
 
-#import <ting-Swift.h>
+#if __has_include("ting-Swift.h")
+    #import <ting-Swift.h>
+#else
+    // When using use_frameworks! :linkage => :static in Podfile
+    #import <Ting/Ting-Swift.h>
+#endif
 
 @implementation Ting
 


### PR DESCRIPTION
Hello Thanks for great library! 

Can you please take a look at fixing ios build issue when using

```rb
use_frameworks! :linkage => :static
```

on Podfile. 

This might fix the issue mentioned at https://github.com/baronha/ting/issues/19 